### PR TITLE
Consumed calculation fix and bug fix when decreases depleted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@
             increase_reads_with : 90,    // read incrase amount (%)
             decrease_reads_with : 30,    // read decrase amount (%)
             base_reads : 5,              // minimum read Capacity
+            high_reads : 100,            // maximum read Capacity
             writes_upper_threshold : 90, // write incrase amount (%)
             writes_lower_threshold : 40, // write decrase amount (%)
             increase_writes_with : 90,   // write incrase amount (%)
             decrease_writes_with : 30,   // write incrase amount (%)
-            base_writes : 5              // minimum write Capacity
+            base_writes : 5,             // minimum write Capacity
+            high_writes : 300            // maximum write Capacity
             }
             ,
             {
@@ -46,11 +48,13 @@
             increase_reads_with : 0,     // to don't scale up reads
             decrease_reads_with : 0,     // to don't scale down reads
             base_reads : 3,
+            high_reads : 100,
             writes_upper_threshold : 90,
             writes_lower_threshold : 40,
             increase_writes_with : 0,    // to don't scale up writes
             decrease_writes_with : 0,    // to don't scale down writes
-            base_writes : 3
+            base_writes : 3,
+            high_writes : 300
             }
             // additional table...
         ]

--- a/config.js
+++ b/config.js
@@ -10,11 +10,13 @@ module.exports = {
             increase_reads_with : 90, // read incrase amount (%)
             decrease_reads_with : 30, // read decrase amount (%)
             base_reads : 5,          // minimum read Capacity
+            high_reads : 100,        // maximum read Capacity
             writes_upper_threshold : 90, // write incrase amount (%)
             writes_lower_threshold : 40, // write decrase amount (%)
             increase_writes_with : 90, // write incrase amount (%)
             decrease_writes_with : 30, // write incrase amount (%)
-            base_writes : 5          // minimum write Capacity
+            base_writes : 5,         // minimum write Capacity
+            high_writes : 100        // maximum write Capacity
             }
             ,
             {
@@ -24,11 +26,13 @@ module.exports = {
             increase_reads_with : 0, // to don't scale up reads
             decrease_reads_with : 0, // to don't scale down reads
             base_reads : 3,
+            high_reads : 100,
             writes_upper_threshold : 90,
             writes_lower_threshold : 40,
             increase_writes_with : 0, // to don't scale up writes
             decrease_writes_with : 0, // to don't scale down writes
-            base_writes : 3
+            base_writes : 3,
+            high_writes : 100
             }
 
             //...

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ exports.handler = function(event, context) {
 
             // 2. calculate new read/write Capacity
             function(readCapa,readUsed,writeCapa,writeUsed,status,remainDecreaseNum,callback){
+                var newReadCapa= tasks.getTask_newCapa(readCapa,readUsed,item.reads_upper_threshold,item.reads_lower_threshold,item.increase_reads_with,item.decrease_reads_with,item.base_reads);
+                var newWriteCapa= tasks.getTask_newCapa(writeCapa,writeUsed,item.writes_upper_threshold,item.writes_lower_threshold,item.increase_writes_with,item.decrease_writes_with,item.base_writes);
+
                 if (status !== 'ACTIVE') {
                     callback({
                                 tableName : item.tableName,
@@ -46,16 +49,24 @@ exports.handler = function(event, context) {
                                 result : 'status is not ACTIVE'
                             });
                 }
-                else if (remainDecreaseNum === 0) {
+                // If we are out of decreases and there are no increases for read or write
+                else if (remainDecreaseNum === 0 && readCapa === Math.max(readCapa, newReadCapa) && writeCapa === Math.max(writeCapa, newWriteCapa) && (readCapa !== newReadCapa || writeCapa !== newWriteCapa)) {
                     callback({
                                 tableName : item.tableName,
                                 code : 'pass',
-                                result : 'Depleted today\'s # of decrease throughput'
+                                result : 'Depleted today\'s # of decrease throughput',
+                                detail : 'read - capacity:'+readCapa+', decreased capacity:'+newReadCapa
+                                    +' // write - capacity:'+writeCapa+', decreased capacity:'+newWriteCapa
                             });
                 }
                 else {
-                    var newReadCapa= tasks.getTask_newCapa(readCapa,readUsed,item.reads_upper_threshold,item.reads_lower_threshold,item.increase_reads_with,item.decrease_reads_with,item.base_reads);
-                    var newWriteCapa= tasks.getTask_newCapa(writeCapa,writeUsed,item.writes_upper_threshold,item.writes_lower_threshold,item.increase_writes_with,item.decrease_writes_with,item.base_writes);
+
+                    // If we are out of decreases set the new capacity to the max of the new and old capacities
+                    if (remainDecreaseNum === 0) {
+                        newReadCapa = Math.max(readCapa, newReadCapa);
+                        newWriteCapa = Math.max(writeCapa, newWriteCapa);
+                    }
+
                     if (readCapa === newReadCapa && writeCapa === newWriteCapa) {
                         callback({
                                 tableName : item.tableName,

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ exports.handler = function(event, context) {
 
             // 2. calculate new read/write Capacity
             function(readCapa,readUsed,writeCapa,writeUsed,status,remainDecreaseNum,callback){
-                var newReadCapa= tasks.getTask_newCapa(readCapa,readUsed,item.reads_upper_threshold,item.reads_lower_threshold,item.increase_reads_with,item.decrease_reads_with,item.base_reads);
-                var newWriteCapa= tasks.getTask_newCapa(writeCapa,writeUsed,item.writes_upper_threshold,item.writes_lower_threshold,item.increase_writes_with,item.decrease_writes_with,item.base_writes);
+                var newReadCapa= tasks.getTask_newCapa(readCapa,readUsed,item.reads_upper_threshold,item.reads_lower_threshold,item.increase_reads_with,item.decrease_reads_with,item.base_reads,item.high_reads);
+                var newWriteCapa= tasks.getTask_newCapa(writeCapa,writeUsed,item.writes_upper_threshold,item.writes_lower_threshold,item.increase_writes_with,item.decrease_writes_with,item.base_writes,item.high_reads);
 
                 if (status !== 'ACTIVE') {
                     callback({

--- a/tasks.js
+++ b/tasks.js
@@ -45,7 +45,7 @@ exports.getTask_consumedReadCapa = function(tableName, callback) {
         Namespace: 'AWS/DynamoDB', //required
         Period: (env.timeframeMin*60), // required
         StartTime: env.startTime, // required
-        Statistics: [ 'Average' ],
+        Statistics: [ 'Sum' ],
         Dimensions: [
         {
             Name: 'TableName', // required
@@ -63,7 +63,7 @@ exports.getTask_consumedReadCapa = function(tableName, callback) {
             });
         }
         else {
-            callback(null,data.Datapoints.length === 0 ? 0 : data.Datapoints[0].Average);
+            callback(null,data.Datapoints.length === 0 ? 0 : Math.round(data.Datapoints[0].Sum/60/env.timeframeMin));
         }
     });
 };
@@ -76,7 +76,7 @@ exports.getTask_consumedWriteCapa = function(tableName, callback) {
         Namespace: 'AWS/DynamoDB', //required
         Period: (env.timeframeMin*60), // required
         StartTime: env.startTime, // required
-        Statistics: [ 'Average' ],
+        Statistics: [ 'Sum' ],
         Dimensions: [
         {
             Name: 'TableName', // required
@@ -94,7 +94,7 @@ exports.getTask_consumedWriteCapa = function(tableName, callback) {
             });
         }
         else {
-            callback(null,data.Datapoints.length === 0 ? 0 : data.Datapoints[0].Average);
+            callback(null,data.Datapoints.length === 0 ? 0 : Math.round(data.Datapoints[0].Sum/60/env.timeframeMin));
         }
     });
 };

--- a/tasks.js
+++ b/tasks.js
@@ -100,11 +100,11 @@ exports.getTask_consumedWriteCapa = function(tableName, callback) {
 };
 
 // calculate Capacity to update
-exports.getTask_newCapa = function(capa,used,upperThsd,lowerThsd,increseAmt,decreseAmt,base) {
+exports.getTask_newCapa = function(capa,used,upperThsd,lowerThsd,increseAmt,decreseAmt,base,high) {
     var rate = (used/capa)*100;
     if ( rate > upperThsd )
     {
-        return Math.round(capa+(capa*(increseAmt/100)));
+        return Math.min(Math.round(capa+(capa*(increseAmt/100))),high);
     }
     else if ( rate < lowerThsd )
     {


### PR DESCRIPTION
I found a couple of problems when trying to use this. First the consumed calculations were not correct. They need to be sum and then divided by the number of seconds in the time window to get consumed/second.

I also found that if you run out of available decreases it would no longer allow increases.

BTW, thank you for this. It is exactly what I was looking for. Nice clean code too.
